### PR TITLE
Add a modprobe sample file for ZigBee board CC2520 and AT86RF230 on MinnowBoard MAX

### DIFF
--- a/recipes-extended/spi-minnowmax-board/files/at86rf230-minnow.conf.sample
+++ b/recipes-extended/spi-minnowmax-board/files/at86rf230-minnow.conf.sample
@@ -1,0 +1,15 @@
+# These modules are required to enable at86rf230 802.15.4 radio in the
+# MinnowBoard MAX
+#
+# To enable loading, link as below:
+#
+# ln -s /usr/lib/modules-load.d/at86rf230-minnow.conf.sample /etc/modules-load.d/at86rf230.conf
+#
+# NOTE: MinnowBoard MAX BIOS must have LPSS SPI enabled.
+spi_pxa2xx_platform
+spi-minnow-at86rf230
+spi-minnow-board
+
+blacklist low_speed-spidev              # avoid being auto-loaded as dependency
+install low_speed-spidev /bin/true      # disable manual install
+

--- a/recipes-extended/spi-minnowmax-board/files/cc2520-minnow.conf.sample
+++ b/recipes-extended/spi-minnowmax-board/files/cc2520-minnow.conf.sample
@@ -1,0 +1,15 @@
+# These modules are required to enable CC2520 802.15.4 radio in the
+# MinnowBoard MAX
+#
+# To enable loading, link as below:
+#
+# ln -s /usr/lib/modules-load.d/cc2520-minnow.conf.sample /etc/modules-load.d/cc2520.conf
+#
+# NOTE: MinnowBoard MAX BIOS must have PWM #1/#2 disabled and LPSS SPI enabled.
+spi_pxa2xx_platform
+spi-minnow-cc2520
+spi-minnow-board
+
+blacklist low_speed-spidev              # avoid being auto-loaded as dependency
+install low_speed-spidev /bin/true      # disable manual install
+

--- a/recipes-extended/spi-minnowmax-board/spi-minnowmax-board.bb
+++ b/recipes-extended/spi-minnowmax-board/spi-minnowmax-board.bb
@@ -13,6 +13,15 @@ SRC_URI = "file://spi-minnow-cc2520.c \
            file://spi-minnow-board.c \
            file://spi-minnow-board.h \
            file://Makefile \
+           file://cc2520-minnow.conf.sample \
            "
+
+FILES_${PN} += " /usr/lib/modules-load.d/cc2520-minnow.conf.sample"
+
+# Sample configuring file
+do_install_append () {
+  install -d ${D}${libdir}/modules-load.d
+  install -m 0655 cc2520-minnow.conf.sample ${D}${libdir}/modules-load.d/
+}
 
 S = "${WORKDIR}"

--- a/recipes-extended/spi-minnowmax-board/spi-minnowmax-board.bb
+++ b/recipes-extended/spi-minnowmax-board/spi-minnowmax-board.bb
@@ -14,14 +14,18 @@ SRC_URI = "file://spi-minnow-cc2520.c \
            file://spi-minnow-board.h \
            file://Makefile \
            file://cc2520-minnow.conf.sample \
+           file://at86rf230-minnow.conf.sample \
            "
 
-FILES_${PN} += " /usr/lib/modules-load.d/cc2520-minnow.conf.sample"
+FILES_${PN} += " /usr/lib/modules-load.d/cc2520-minnow.conf.sample \
+                 /usr/lib/modules-load.d/at86rf230-minnow.conf.sample \
+               "
 
 # Sample configuring file
 do_install_append () {
   install -d ${D}${libdir}/modules-load.d
   install -m 0655 cc2520-minnow.conf.sample ${D}${libdir}/modules-load.d/
+  install -m 0655 at86rf230-minnow.conf.sample ${D}${libdir}/modules-load.d/
 }
 
 S = "${WORKDIR}"


### PR DESCRIPTION
In order to use the these zigBee raido boards, some kernel modules should be loaded,
add this config file as a how-to example for users

Signed-off-by: Yong Li yong.b.li@intel.com
