### PR TITLE
Add modprobe sample files and systemd service files for 802.15.4 radio boards

### DIFF
--- a/recipes-extended/spi-minnowmax-board/files/modprobe.d/spi-minnow-at86rf230.conf.sample
+++ b/recipes-extended/spi-minnowmax-board/files/modprobe.d/spi-minnow-at86rf230.conf.sample
@@ -1,0 +1,16 @@
+# These modules are required to enable AT86RF230 802.15.4 radio in the
+# MinnowBoard MAX
+#
+# To enable loading, link as below:
+#
+# install: ln -s /lib/modprobe.d/spi-minnow-at86rf230.conf.sample /etc/modprobe.d/spi-minnow-at86rf230.conf
+# to-autoload: ln -s /usr/lib/modules-load.d/at86rf230.conf.sample /etc/modules-load.d/at86rf230.conf
+#
+# NOTE: MinnowBoard MAX BIOS must have LPSS SPI enabled.
+
+blacklist spi-minnow-cc2520
+install spi-minnow-cc2520 /bin/true
+
+blacklist low_speed-spidev              # avoid being auto-loaded as dependency
+install low_speed-spidev /bin/true      # disable manual install
+

--- a/recipes-extended/spi-minnowmax-board/files/modprobe.d/spi-minnow-cc2520.conf.sample
+++ b/recipes-extended/spi-minnowmax-board/files/modprobe.d/spi-minnow-cc2520.conf.sample
@@ -1,0 +1,16 @@
+# These modules are required to enable CC2520 802.15.4 radio in the
+# MinnowBoard MAX
+#
+# To enable loading, link as below:
+#
+# install: ln -s /lib/modprobe.d/spi-minnow-cc2520.conf.sample /etc/modprobe.d/spi-minnow-cc2520.conf
+# to-autoload: ln -s /usr/lib/modules-load.d/cc2520.conf.sample /etc/modules-load.d/cc2520.conf
+#
+# NOTE: MinnowBoard MAX BIOS must have PWM #1/#2 disabled and LPSS SPI enabled.
+
+blacklist spi-minnow-at86rf230
+install spi-minnow-at86rf230 /bin/true
+
+blacklist low_speed-spidev              # avoid being auto-loaded as dependency
+install low_speed-spidev /bin/true      # disable manual install
+

--- a/recipes-extended/spi-minnowmax-board/files/modules-load.d/at86rf230.conf.sample
+++ b/recipes-extended/spi-minnowmax-board/files/modules-load.d/at86rf230.conf.sample
@@ -1,0 +1,12 @@
+# These modules are required to enable AT86RF230 802.15.4 radio in the
+# MinnowBoard MAX
+#
+# To enable loading, link as below:
+#
+# requirement: ln -s /lib/modprobe.d/spi-minnow-at86rf230.conf.sample /etc/modprobe.d/spi-minnow-at86rf230.conf
+# install: ln -s /usr/lib/modules-load.d/at86rf230.conf.sample /etc/modules-load.d/at86rf230.conf
+#
+# NOTE: MinnowBoard MAX BIOS must have LPSS SPI enabled.
+spi_pxa2xx_platform
+spi-minnow-at86rf230
+spi-minnow-board

--- a/recipes-extended/spi-minnowmax-board/files/modules-load.d/cc2520.conf.sample
+++ b/recipes-extended/spi-minnowmax-board/files/modules-load.d/cc2520.conf.sample
@@ -1,0 +1,12 @@
+# These modules are required to enable CC2520 802.15.4 radio in the
+# MinnowBoard MAX
+#
+# To enable loading, link as below:
+#
+# requirement: ln -s /lib/modprobe.d/spi-minnow-cc2520.conf.sample /etc/modprobe.d/spi-minnow-cc2520.conf
+# install: ln -s /usr/lib/modules-load.d/cc2520.conf.sample /etc/modules-load.d/cc2520.conf
+#
+# NOTE: MinnowBoard MAX BIOS must have PWM #1/#2 disabled and LPSS SPI enabled.
+spi_pxa2xx_platform
+spi-minnow-cc2520
+spi-minnow-board

--- a/recipes-extended/spi-minnowmax-board/files/ostro-6lowpan-start.sh
+++ b/recipes-extended/spi-minnowmax-board/files/ostro-6lowpan-start.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+if [ -z "$HWADDR" ]; then
+    HWADDR=`ip link show wpan0 | grep -e link/ieee802.15.4 | sed -e 's#^.*link/ieee802.15.4 \([0-9a-fA-F:]\+\) .*$#\1#g'`
+    if [ -z "$HWADDR" ]; then
+        HWADDR=`sed /etc/machine-id -e 's#\([0-9a-fA-F]\{2\}\)#\1:#g' | cut -d: -f1-8`
+    fi
+fi
+
+if [ -z "$PAN" ]; then
+    PAN=777
+fi
+
+if [ -z "$ADDR" ]; then
+    ADDR=`echo $HWADDR  | cut -d: -f7-8 | tr -d :`
+fi
+
+if [ -z "$CHANNEL" ]; then
+    CHANNEL=`iz listphy | grep -e "channels on page 0:" | sed -e 's#^.*channels on page 0: \([0-9a-fA-F:]\+\) .*$#\1#g'`
+fi
+
+if [ -z "$CHANNEL" ]; then
+    CHANNEL=11
+fi
+
+ip link set wpan0 address ${HWADDR}
+iz set wpan0 ${PAN} ${ADDR} ${CHANNEL}
+ifconfig wpan0 up
+ip link add link wpan0 name lowpan0 type lowpan
+ifconfig lowpan0 up
+

--- a/recipes-extended/spi-minnowmax-board/files/ostro-6lowpan-stop.sh
+++ b/recipes-extended/spi-minnowmax-board/files/ostro-6lowpan-stop.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+ifconfig lowpan0 down
+ifconfig wpan0 down
+ip link del lowpan0

--- a/recipes-extended/spi-minnowmax-board/files/ostro-6lowpan.service
+++ b/recipes-extended/spi-minnowmax-board/files/ostro-6lowpan.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=6loWPAN network setup
+Before=connman.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=-/etc/ostro-6lowpan.conf
+ExecStart=/usr/lib/ostro-scripts/ostro-6lowpan-start.sh
+ExecStop=/usr/lib/ostro-scripts/ostro-6lowpan-stop.sh
+
+[Install]
+WantedBy=multi-user.target
+

--- a/recipes-extended/spi-minnowmax-board/spi-minnowmax-board.bb
+++ b/recipes-extended/spi-minnowmax-board/spi-minnowmax-board.bb
@@ -17,12 +17,18 @@ SRC_URI = "file://spi-minnow-cc2520.c \
            file://modprobe.d/spi-minnow-cc2520.conf.sample \
            file://modules-load.d/at86rf230.conf.sample \
            file://modprobe.d/spi-minnow-at86rf230.conf.sample \
+           file://ostro-6lowpan.service \
+           file://ostro-6lowpan-start.sh \
+           file://ostro-6lowpan-stop.sh \
            "
 
 FILES_${PN} += " /usr/lib/modules-load.d/cc2520.conf.sample \
                  /usr/lib/modules-load.d/at86rf230.conf.sample \
                  /lib/modprobe.d/spi-minnow-cc2520.conf.sample \
                  /lib/modprobe.d/spi-minnow-at86rf230.conf.sample \
+                 ${systemd_unitdir}/system/ostro-6lowpan.service \
+                 ${libdir}/ostro-scripts/ostro-6lowpan-start.sh \
+                 ${libdir}/ostro-scripts/ostro-6lowpan-stop.sh \
                "
 
 # Sample configuring file
@@ -33,6 +39,11 @@ do_install_append () {
 	install -m 0644 modprobe.d/spi-minnow-cc2520.conf.sample ${D}${base_libdir}/modprobe.d/
 	install -m 0644 modules-load.d/at86rf230.conf.sample ${D}${libdir}/modules-load.d/
 	install -m 0644 modprobe.d/spi-minnow-at86rf230.conf.sample ${D}${base_libdir}/modprobe.d/
+	install -d -m 755 ${D}${systemd_unitdir}/system/
+	install -m 0644 ostro-6lowpan.service ${D}${systemd_unitdir}/system/
+	install -d -m 755 ${D}${libdir}/ostro-scripts/
+	install -m 0755 ostro-6lowpan-start.sh ${D}${libdir}/ostro-scripts/
+	install -m 0755 ostro-6lowpan-stop.sh ${D}${libdir}/ostro-scripts/
 }
 
 S = "${WORKDIR}"

--- a/recipes-extended/spi-minnowmax-board/spi-minnowmax-board.bb
+++ b/recipes-extended/spi-minnowmax-board/spi-minnowmax-board.bb
@@ -13,6 +13,26 @@ SRC_URI = "file://spi-minnow-cc2520.c \
            file://spi-minnow-board.c \
            file://spi-minnow-board.h \
            file://Makefile \
+           file://modules-load.d/cc2520.conf.sample \
+           file://modprobe.d/spi-minnow-cc2520.conf.sample \
+           file://modules-load.d/at86rf230.conf.sample \
+           file://modprobe.d/spi-minnow-at86rf230.conf.sample \
            "
+
+FILES_${PN} += " /usr/lib/modules-load.d/cc2520.conf.sample \
+                 /usr/lib/modules-load.d/at86rf230.conf.sample \
+                 /lib/modprobe.d/spi-minnow-cc2520.conf.sample \
+                 /lib/modprobe.d/spi-minnow-at86rf230.conf.sample \
+               "
+
+# Sample configuring file
+do_install_append () {
+	install -d -m 755 ${D}${base_libdir}/modprobe.d
+	install -d -m 755 ${D}${libdir}/modules-load.d
+	install -m 0644 modules-load.d/cc2520.conf.sample ${D}${libdir}/modules-load.d/
+	install -m 0644 modprobe.d/spi-minnow-cc2520.conf.sample ${D}${base_libdir}/modprobe.d/
+	install -m 0644 modules-load.d/at86rf230.conf.sample ${D}${libdir}/modules-load.d/
+	install -m 0644 modprobe.d/spi-minnow-at86rf230.conf.sample ${D}${base_libdir}/modprobe.d/
+}
 
 S = "${WORKDIR}"


### PR DESCRIPTION
…0 on MinnowBoard MAX

In order to use these 802.15.4 boards, some kernel modules must be loaded,
add these config files as a how-to example for users

Signed-off-by: Yong Li yong.b.li@intel.com
