### PR TITLE
image_types_edison: default IMAGE_NAME in flashall.sh

### DIFF
--- a/meta-edison-bsp/classes/image_types_edison.bbclass
+++ b/meta-edison-bsp/classes/image_types_edison.bbclass
@@ -105,6 +105,8 @@ IMAGE_CMD_toflash () {
 	install ${DEPLOY_DIR_IMAGE}/flashall/helper/helper.html	${WORKDIR}/toFlash/helper/
 	install ${DEPLOY_DIR_IMAGE}/flashall/helper/images/*.png ${WORKDIR}/toFlash/helper/images/
 
+	# update image name inside flashall.sh
+	sed -e "s/^IMAGE_NAME=.\+$/IMAGE_NAME=\"${IMAGE_BASENAME}\"/" -i ${WORKDIR}/toFlash/flashall.sh
 
 	# generate a formatted list of all packages included in the image
 	awk '{print $1 " " $3}' ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.manifest > ${WORKDIR}/toFlash/package-list.txt


### PR DESCRIPTION
Put IMAGE_BASENAME as default name in flashall.sh

Fixes: ostroproject/ostro-os#4

Signed-off-by: Alexander Kanevskiy kad@linux.intel.com
