### PR TITLE
meta-edison-bsp: u-boot-edison: adapt to file:// fetcher changes

### DIFF
--- a/meta-edison-bsp/recipes-bsp/u-boot/u-boot-internal.inc
+++ b/meta-edison-bsp/recipes-bsp/u-boot/u-boot-internal.inc
@@ -5,7 +5,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 SRC_URI = "git://github.com/01org/edison-u-boot.git;branch=edison-v2014.04;protocol=git" 
 SRC_URI += "${@'file://${MACHINE}.env' if '${MACHINE}' in ('edison',) else ''}"
-SRC_URI += "file://target_env/*.env"
+SRC_URI += "file://target_env/"
 SRC_URI += "file://0001-Backport-compiler-gcc.h-from-4.2-kernel.patch"
 SRC_URI += "file://0002-Fix-weak-external-function-references-for-gcc5.patch"
 SRC_URI += "file://0001-Fix-missing-stdint.h-include.patch"


### PR DESCRIPTION
bitbake rev: e659a3b0c2771679057ee3e13cd42e6c62383ff2 changed how file://dir/*
behaves and that triggered a problem in unpacking .env files in target_env.

This resulted in some of the do_\* tasks not finding the right .env files and
eventually do_deploy failed.

Thus, adapt to the new (fixed) behavior of file:// fetcher.

Signed-off-by: Mikko Ylinen mikko.ylinen@intel.com
