### PR TITLE
adjust the SPI clock on Galileo GEN 2 boards, for stable connection

### DIFF
--- a/recipes-extended/spi-quark-board/files/spi-quark-at86rf230.c
+++ b/recipes-extended/spi-quark-board/files/spi-quark-at86rf230.c
@@ -22,7 +22,7 @@
 #define AT86RF_SPI_MASTER 169
 
 #define AT86RF_SPI_CS 0
-#define AT86RF_MAX_CLK_HZ  5000000
+#define AT86RF_MAX_CLK_HZ  3000000
 #define AT86RF_IRQ 14
 
 static struct gpio quark_at86rf_gpios[] = {


### PR DESCRIPTION
On Galileo GEN 2 boards, when the SPI clock is 5MHz,
the communication is unstable, decrease the clock to 3M

Fix: IOTOS-1319

Signed-off-by: Yong Li yong.b.li@intel.com
