### PR TITLE
spi-quark-board:Add 802.15.4 radio board related module load sample files and systemd…

### DIFF
--- a/recipes-extended/spi-quark-board/files/modules-load.d/at86rf230.conf.sample
+++ b/recipes-extended/spi-quark-board/files/modules-load.d/at86rf230.conf.sample
@@ -1,0 +1,9 @@
+# These modules are required to enable AT86RF230 802.15.4 radio in the
+# Galileo Gen 2
+#
+# To enable loading, link as below:
+#
+# install: ln -s /usr/lib/modules-load.d/at86rf230.conf.sample /etc/modules-load.d/at86rf230.conf
+#
+spi-quark-at86rf230
+spi-quark-board

--- a/recipes-extended/spi-quark-board/spi-quark-board.bb
+++ b/recipes-extended/spi-quark-board/spi-quark-board.bb
@@ -12,6 +12,15 @@ SRC_URI = "file://spi-quark-at86rf230.c \
            file://spi-quark-board.c \
            file://spi-quark-board.h \
            file://Makefile \
+           file://modules-load.d/at86rf230.conf.sample \
            "
+
+FILES_${PN} += " /usr/lib/modules-load.d/at86rf230.conf.sample \
+               "
+# Sample configuring file
+do_install_append () {
+	install -d -m 755 ${D}${libdir}/modules-load.d
+	install -m 0644 modules-load.d/at86rf230.conf.sample ${D}${libdir}/modules-load.d/
+}
 
 S = "${WORKDIR}"


### PR DESCRIPTION
… service files

In order to use the Atmel AT86RF212 802.15.4 radio boards on Galileo Gen 2 boards,
Add the kernel modules auto load sample files, and systemd service files for the 6lowpan configuration

The service start script will generate the config settings based on the hardware address,
or you can use the below commands to set:
    echo "HWADDR=a0:0:0:0:0:0:0:1" > /etc/ostro-6lowpan.conf
    echo "PAN=777" >> /etc/ostro-6lowpan.conf
    echo "ADDR=8001" >> /etc/ostro-6lowpan.conf
    echo " CHANNEL=5" >> /etc/ostro-6lowpan.conf

```
systemctl enable ostro-6lowpan
systemctl start ostro-6lowpan
```

Signed-off-by: Yong Li yong.b.li@intel.com
