### PR TITLE
Use ostro-6lowpan package to configure the 802.15.4

### DIFF
--- a/recipes-extended/spi-minnowmax-board/spi-minnowmax-board.bb
+++ b/recipes-extended/spi-minnowmax-board/spi-minnowmax-board.bb
@@ -11,6 +11,8 @@ inherit module
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files/:"
 
+RRECOMMENDS_${PN} = "ostro-6lowpan"
+
 SRC_URI = "file://spi-minnow-cc2520.c \
            file://spi-minnow-at86rf230.c \
            file://spi-minnow-board.c \

--- a/recipes-extended/spi-quark-board/spi-quark-board.bb
+++ b/recipes-extended/spi-quark-board/spi-quark-board.bb
@@ -11,6 +11,8 @@ inherit module
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files/:"
 
+RRECOMMENDS_${PN} = "ostro-6lowpan"
+
 SRC_URI = "file://spi-quark-at86rf230.c \
            file://spi-quark-board.c \
            file://spi-quark-board.h \


### PR DESCRIPTION
ostro-6lowpan provides the related systemd service files to configure 802.15.4,
spi-quark-baord and spi-minnowmax-board can use it as a runtime recommend

Signed-off-by: Yong Li yong.b.li@intel.com
