### PR TITLE
edison-bsp: increase rootfs size to two gigabytes.

### DIFF
--- a/meta-edison-bsp/conf/machine/edison.conf
+++ b/meta-edison-bsp/conf/machine/edison.conf
@@ -23,10 +23,10 @@ MACHINE_FEATURES = "bluetooth alsa pci serial usbgadget usbhost wifi x86 ext3"
 IMAGE_CLASSES += "image_types_edison"
 IMAGE_FSTYPES = "tar.bz2 ext4 toflash"
 
-# we want rootfs size of 1572864
+# we want rootfs size of 2097152
 # rootfs_rpm.bbclass adds 51200
-# so adjust to 1572864 - 51200
-IMAGE_ROOTFS_SIZE = "1521664"
+# so adjust to 2097152 - 51200
+IMAGE_ROOTFS_SIZE = "2045952"
 # Also, Ostro OS is not allowed to ask for additional space either.
 # TODO: this should be a variable from OE-core which gets
 # added by rootfs_rpm.bbclass, instead of doing the increase twice

--- a/meta-edison-bsp/recipes-bsp/u-boot/files/edison.env
+++ b/meta-edison-bsp/recipes-bsp/u-boot/files/edison.env
@@ -2,7 +2,7 @@
 # Main part
 
 # Partition definition
-partitions=uuid_disk=${uuid_disk};name=u-boot0,start=1MiB,size=2MiB,uuid=${uuid_uboot0};name=u-boot-env0,size=1MiB,uuid=${uuid_uboot_env0};name=u-boot1,size=2MiB,uuid=${uuid_uboot1};name=u-boot-env1,size=1MiB,uuid=${uuid_uboot_env1};name=factory,size=1MiB,uuid=${uuid_factory};name=panic,size=24MiB,uuid=${uuid_panic};name=boot,size=32MiB,uuid=${uuid_boot};name=rootfs,size=1536MiB,uuid=${uuid_rootfs};name=update,size=768MiB,uuid=${uuid_update};name=home,size=-,uuid=${uuid_home};
+partitions=uuid_disk=${uuid_disk};name=u-boot0,start=1MiB,size=2MiB,uuid=${uuid_uboot0};name=u-boot-env0,size=1MiB,uuid=${uuid_uboot_env0};name=u-boot1,size=2MiB,uuid=${uuid_uboot1};name=u-boot-env1,size=1MiB,uuid=${uuid_uboot_env1};name=factory,size=1MiB,uuid=${uuid_factory};name=panic,size=24MiB,uuid=${uuid_panic};name=boot,size=32MiB,uuid=${uuid_boot};name=rootfs,size=2048MiB,uuid=${uuid_rootfs};name=update,size=768MiB,uuid=${uuid_update};name=home,size=-,uuid=${uuid_home};
 
 # Dfu Alternate setting definition
 do_dfu_alt_info_mmc=setenv dfu_alt_info "ifwi${hardware_id} mmc 0 8192 mmcpart 1;ifwib${hardware_id} mmc 0 8192 mmcpart 2;u-boot0 part 0 1;u-boot-env0 part 0 2;u-boot1 part 0 3;u-boot-env1 part 0 4;boot part 0 7;rootfs part 0 8;update part 0 9;home part 0 10;vmlinuz fat 0 7;initrd fat 0 7"


### PR DESCRIPTION
Increase Edison rootfs size to make `-dev` image flashing work again. This is a temporary fix. In
the future we can probably drop "update" partition completely. We can also adjust image sizes so that the "home" partition is bigger on reference images and smaller on development images to accommodate development tools on root filesystem.
