### PR TITLE
Use COMPATIBLE_MACHINE with some kernel modules

### DIFF
--- a/meta-edison-bsp/recipes-kernel/bcm43340/bcm43340-mod.bb
+++ b/meta-edison-bsp/recipes-kernel/bcm43340/bcm43340-mod.bb
@@ -5,6 +5,9 @@ SRC_URI = "git://github.com/01org/edison-bcm43340.git;branch=master;protocol=git
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=f9986853fb3b3403700e7535a392d014"
 
+# The module is compatible with Edison kernel only
+COMPATIBLE_MACHINE="edison"
+
 inherit module
 
 PV = "1.141"

--- a/recipes-extended/spi-minnowmax-board/spi-minnowmax-board.bb
+++ b/recipes-extended/spi-minnowmax-board/spi-minnowmax-board.bb
@@ -4,6 +4,9 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${THISDIR}/files/COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 PR = "r0"
 
+# The module is compatible with intel-corei7-64/Minnowboard only
+COMPATIBLE_MACHINE="intel-corei7-64"
+
 inherit module
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files/:"

--- a/recipes-extended/spi-quark-board/spi-quark-board.bb
+++ b/recipes-extended/spi-quark-board/spi-quark-board.bb
@@ -4,6 +4,9 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${THISDIR}/files/COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 PR = "r0"
 
+# The module is compatible with intel-quark/Galileo Gen2 only
+COMPATIBLE_MACHINE="intel-quark"
+
 inherit module
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files/:"


### PR DESCRIPTION
bcm43340-mod, spi-minnowmax-board, and spi-quark-board
are clearly MACHINE specific and thus they should declare
COMPATIBLE_MACHINE they are compatible with.

This change is needed to fix the world build.

Signed-off-by: Mikko Ylinen mikko.ylinen@intel.com
