### PR TITLE
linux-yocto: move corei7-64 SRCREV ahead for BXT

### DIFF
--- a/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
+++ b/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
@@ -1,5 +1,9 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-yocto:"
 
+# version overrides
+LINUX_VERSION_corei7-64-intel-common = "4.4.3"
+SRCREV_machine_corei7-64-intel-common = "73481a3abd4ee49c1cf5561fea997275f535098e"
+
 ### Config "fix" fragments
 
 # security fixes


### PR DESCRIPTION
Move kernel SRCREV ahead for corei7-64 to support Intel Broxton
platforms.

Signed-off-by: Jussi Laako jussi.laako@linux.intel.com
