### PR TITLE
u-boot-edison: disable running fsck at boot time

### DIFF
--- a/meta-edison-bsp/recipes-bsp/u-boot/files/edison.env
+++ b/meta-edison-bsp/recipes-bsp/u-boot/files/edison.env
@@ -19,7 +19,7 @@ first_install_max_retries=3
 audio_codec_name=audio_codec="dummy"
 do_audio_support=setenv audio_support platform_mrfld_audio.${audio_codec_name}
 do_compute_target=if itest.b ${first_install_retry} -gt ${first_install_max_retries} ; then echo "Switch to Rescue target"; setenv bootargs_target rescue; saveenv; fi
-mmc-bootargs=run do_bootargs_rootfs; run do_audio_support; setenv bootargs ${bootargs_rootfs} ${bootargs_console} ${bootargs_debug} g_multi.ethernet_config=${bootargs_ethconfig} systemd.unit=${bootargs_target}.target hardware_id=${hardware_id} g_multi.iSerialNumber=${serial#} g_multi.dev_addr=${usb0addr} ${audio_support}
+mmc-bootargs=run do_bootargs_rootfs; run do_audio_support; setenv bootargs ${bootargs_rootfs} ${bootargs_console} ${bootargs_debug} g_multi.ethernet_config=${bootargs_ethconfig} systemd.unit=${bootargs_target}.target hardware_id=${hardware_id} g_multi.iSerialNumber=${serial#} g_multi.dev_addr=${usb0addr} ${audio_support} fsck.mode=skip
 loadaddr=0x100000
 load_kernel=mmc rescan;if fatload mmc 1:1 ${loadaddr} vmlinuz;then echo "Booting from SD ...";setenv rootfs /dev/mmcblk1p2;else fatload mmc 0:7 ${loadaddr} vmlinuz;echo "Booting from emmc ...";setenv rootfs PARTUUID=${uuid_rootfs};fi;
 


### PR DESCRIPTION
Disable running fsck at boot. System clock is typically wrong at early
boot stage due to lack of RTC backup battery. This causes unnecessary
fixes being made due to filesystem metadata time stamps being in future.

Ostro images use journaling filesystem and thus running fsck at boot is
not necessary.

Signed-off-by: Jussi Laako jussi.laako@linux.intel.com
