### PR TITLE
Fix the incorrect machine name for Edison boards

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -24,7 +24,7 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS_append_intel-quark = " \
     i2c-quark-board \
 "
 
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS_append_intel-edison = " \
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_append_edison = " \
     i2c-edison-board \
 "
 


### PR DESCRIPTION
The i2c-edison-board package is missing on Edison board due to the incorrect machine name
Fix this issue by using correct machine name

Fixes: IOTOS-757/partial

Signed-off-by: Yong Li yong.b.li@intel.com
