### PR TITLE
backport iio-ak8975-Add-device-name patch for linux-yocto-edison 3.10

### DIFF
--- a/recipes-kernel/linux-yocto/linux-yocto/0001-iio-ak8975-Add-device-name.patch
+++ b/recipes-kernel/linux-yocto/linux-yocto/0001-iio-ak8975-Add-device-name.patch
@@ -1,0 +1,28 @@
+From 54ab3e244d0b7e80120778503c697b9997cf673b Mon Sep 17 00:00:00 2001
+From: Beomho Seo <beomho.seo@samsung.com>
+Date: Wed, 2 Apr 2014 09:16:00 +0100
+Subject: [PATCH] iio: ak8975: Add device name
+
+This patch add device name.
+
+Signed-off-by: Beomho Seo <beomho.seo@samsung.com>
+Signed-off-by: Jonathan Cameron <jic23@kernel.org>
+---
+ drivers/iio/magnetometer/ak8975.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/iio/magnetometer/ak8975.c b/drivers/iio/magnetometer/ak8975.c
+index ff284e5..039c3e8 100644
+--- a/drivers/iio/magnetometer/ak8975.c
++++ b/drivers/iio/magnetometer/ak8975.c
+@@ -511,6 +511,7 @@ static int ak8975_probe(struct i2c_client *client,
+ 	indio_dev->channels = ak8975_channels;
+ 	indio_dev->num_channels = ARRAY_SIZE(ak8975_channels);
+ 	indio_dev->info = &ak8975_info;
++	indio_dev->name = id->name;
+ 	indio_dev->modes = INDIO_DIRECT_MODE;
+ 
+ 	err = iio_device_register(indio_dev);
+-- 
+2.5.0
+

--- a/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
+++ b/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
@@ -124,3 +124,6 @@ SRC_URI_append = " file://ecryptfs.cfg"
 # Backport ambient capabilities support
 SRC_URI_append_edison = " file://0001-edison-capabilities-ambient-capabilities.patch"
 SRC_URI_append_edison = " file://0002-edison-capabilities-add-a-securebit-to-disable-PR_CAP_AMBIE.patch"
+
+# Backport AK8975 iio device name support
+SRC_URI_append_edison = " file://0001-iio-ak8975-Add-device-name.patch"


### PR DESCRIPTION
The magnetometer sensor ak8975 driver does not set the iio name in linux-yocto-edison 3.10,
backport the patch to support more sensors

Fixes: IOTOS-1520
Upstream-Status:Backport[https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=54ab3e244d0b7e80120778503c697b9997cf673b]

Signed-off-by: Yong Li yong.b.li@intel.com
