### PR TITLE
set the correct interrupt trigger type for Galileo boards

### DIFF
--- a/recipes-extended/spi-quark-board/files/spi-quark-board.c
+++ b/recipes-extended/spi-quark-board/files/spi-quark-board.c
@@ -42,8 +42,10 @@ static int __init galileo_module_init(void)
 	if (!dev)
 		goto out;
 
-	if (spi_irq)
+	if (spi_irq) {
 		dev->irq = gpio_to_irq(spi_irq);
+		irq_set_irq_type(dev->irq, IRQF_TRIGGER_RISING);
+	}
 
 	pr_info("802.15.4 chip registered\n");
 	err = 0;

--- a/recipes-extended/spi-quark-board/files/spi-quark-board.h
+++ b/recipes-extended/spi-quark-board/files/spi-quark-board.h
@@ -3,6 +3,8 @@
 
 #include <linux/platform_device.h>
 #include <linux/module.h>
+#include <linux/interrupt.h>
+#include <linux/irq.h>
 #include <linux/spi/spi.h>
 #include <linux/gpio.h>
 #include <linux/spi/pxa2xx_spi.h>


### PR DESCRIPTION
After upgraded kernel from 4.1.18 to 4.4.3, the AT86RF230 device driver changed the default IRQ trigger type from RISING to HIGH,
This caused the device does not work on Galileo Gen 2 boards, set the default trigger type to RISING to fix this issue

Fixes: IOTOS-1500

Signed-off-by: Yong Li yong.b.li@intel.com
