### PR TITLE
meta-ostro-bsp: Update linux-yocto-4.4 revision for Galileo boards

### DIFF
--- a/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
+++ b/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/linux-yocto:"
 # version overrides
 LINUX_VERSION_corei7-64-intel-common = "4.4.3"
 SRCREV_machine_corei7-64-intel-common = "1a72cec834de2c80b5563f8afbeea7664fd5ee05"
+SRCREV_machine_i586-nlp-32-intel-common = "0148b3601f29b159b4f84c1478ff1859bbd48efe"
 
 ### linux-stable/linux-4.4.y backports
 


### PR DESCRIPTION
Update the revision to include several Galileo GPIO related patches

Fixes: IOTOS-1365

Signed-off-by: Yong Li yong.b.li@intel.com
