### PR TITLE
Update linux-yocto-4.4 bbapppend to match upstream

### DIFF
--- a/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
+++ b/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
@@ -2,13 +2,10 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/linux-yocto:"
 
 # version overrides
 LINUX_VERSION_corei7-64-intel-common = "4.4.3"
-SRCREV_machine_corei7-64-intel-common = "1a72cec834de2c80b5563f8afbeea7664fd5ee05"
+SRCREV_machine_corei7-64-intel-common = "076cc85486fda808582bd1e77400a5c49dea3e2e"
 
 ### linux-stable/linux-4.4.y backports
 
-SRC_URI_append_intel-quark = " file://0001-sched-cgroup-Fix-cleanup-cgroup-teardown-init.patch"
-SRC_URI_append_intel-corei7-64 = " file://0001-sched-cgroup-Fix-cleanup-cgroup-teardown-init.patch"
-SRC_URI_append_intel-core2-32 = " file://0001-sched-cgroup-Fix-cleanup-cgroup-teardown-init.patch"
 
 ### Config "fix" fragments
 


### PR DESCRIPTION
Update linux-yocto-4.4 bbappend to match upstream meta-intel HEAD by
dropping patches that are now upstream.

Also forward the x64 SRCREV to track HEAD of the linux-yocto kernel tree
for latest Intel Broxton platform patches.

Signed-off-by: Jussi Laako jussi.laako@linux.intel.com
