### PR TITLE
fix the incorrect device name for IIO device TMP006

### DIFF
--- a/recipes-kernel/linux-yocto/linux-yocto/0001-iio-tmp006-Set-correct-iio-name.patch
+++ b/recipes-kernel/linux-yocto/linux-yocto/0001-iio-tmp006-Set-correct-iio-name.patch
@@ -1,0 +1,33 @@
+From a1dbe23dac5f38c92714f69d0cac749c5e954aa7 Mon Sep 17 00:00:00 2001
+From: Yong Li <yong.b.li@intel.com>
+Date: Fri, 22 Apr 2016 11:28:24 +0800
+Subject: [PATCH] iio: tmp006: Set correct iio name
+
+When load the driver using the below command:
+echo tmp006 0x40 > /sys/bus/i2c/devices/i2c-0/new_device
+
+In sysfs, the i2c name is tmp006, however the iio name is 0-0040,
+they are inconsistent. With this patch,
+the iio name will be the same as the i2c device name
+
+Signed-off-by: Yong Li <yong.b.li@intel.com>
+---
+ drivers/iio/temperature/tmp006.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/iio/temperature/tmp006.c b/drivers/iio/temperature/tmp006.c
+index 18c9b43..17c8413 100644
+--- a/drivers/iio/temperature/tmp006.c
++++ b/drivers/iio/temperature/tmp006.c
+@@ -221,7 +221,7 @@ static int tmp006_probe(struct i2c_client *client,
+ 	data->client = client;
+ 
+ 	indio_dev->dev.parent = &client->dev;
+-	indio_dev->name = dev_name(&client->dev);
++	indio_dev->name = id->name;
+ 	indio_dev->modes = INDIO_DIRECT_MODE;
+ 	indio_dev->info = &tmp006_info;
+ 
+-- 
+2.5.0
+

--- a/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
+++ b/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
@@ -43,6 +43,11 @@ SRC_URI_append_intel-corei7-64 = " file://0001-iio-st-accel-add-support-for-lis2
 SRC_URI_append_intel-core2-32 = " file://0001-iio-st-accel-add-support-for-lis2dh12.patch"
 SRC_URI_append_intel-quark = " file://0001-iio-st-accel-add-support-for-lis2dh12.patch"
 
+# Add patch to fix incorrect device name of IIO device TMP006
+SRC_URI_append_intel-corei7-64 = " file://0001-iio-tmp006-Set-correct-iio-name.patch"
+SRC_URI_append_intel-core2-32 = " file://0001-iio-tmp006-Set-correct-iio-name.patch"
+SRC_URI_append_intel-quark = " file://0001-iio-tmp006-Set-correct-iio-name.patch"
+
 #  BeagleBone Black enable all I2Cs
 SRC_URI_append_beaglebone = " file://0001-v3.15.0-ARM-dts-am335x-boneblack-configure-i2c1-and-2.patch"
 


### PR DESCRIPTION
When load the driver using the below command:
echo tmp006 0x40 > /sys/bus/i2c/devices/i2c-0/new_device

In sysfs, the i2c name is tmp006, however the iio name is 0-0040,
they are inconsistent. With this patch,
the iio name will be the same as the i2c device name

Fixes: IOTOS-1516
Upstream-Status:Submitted[http://www.spinics.net/lists/linux-iio/msg24331.html]
Signed-off-by: Yong Li yong.b.li@intel.com
