### PR TITLE
Fix for CVE-2016-3955

### DIFF
--- a/recipes-kernel/linux-yocto/linux-yocto/0001-USB-usbip-fix-potential-out-of-bounds-write.patch
+++ b/recipes-kernel/linux-yocto/linux-yocto/0001-USB-usbip-fix-potential-out-of-bounds-write.patch
@@ -1,0 +1,45 @@
+From b348d7dddb6c4fbfc810b7a0626e8ec9e29f7cbb Mon Sep 17 00:00:00 2001
+From: Ignat Korchagin <ignat.korchagin@gmail.com>
+Date: Thu, 17 Mar 2016 18:00:29 +0000
+Subject: [PATCH] USB: usbip: fix potential out-of-bounds write
+
+Fix potential out-of-bounds write to urb->transfer_buffer
+usbip handles network communication directly in the kernel. When receiving a
+packet from its peer, usbip code parses headers according to protocol. As
+part of this parsing urb->actual_length is filled. Since the input for
+urb->actual_length comes from the network, it should be treated as untrusted.
+Any entity controlling the network may put any value in the input and the
+preallocated urb->transfer_buffer may not be large enough to hold the data.
+Thus, the malicious entity is able to write arbitrary data to kernel memory.
+
+Signed-off-by: Ignat Korchagin <ignat.korchagin@gmail.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/usb/usbip/usbip_common.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/drivers/usb/usbip/usbip_common.c b/drivers/usb/usbip/usbip_common.c
+index facaaf0..e40da77 100644
+--- a/drivers/usb/usbip/usbip_common.c
++++ b/drivers/usb/usbip/usbip_common.c
+@@ -741,6 +741,17 @@ int usbip_recv_xbuff(struct usbip_device *ud, struct urb *urb)
+ 	if (!(size > 0))
+ 		return 0;
+ 
++	if (size > urb->transfer_buffer_length) {
++		/* should not happen, probably malicious packet */
++		if (ud->side == USBIP_STUB) {
++			usbip_event_add(ud, SDEV_EVENT_ERROR_TCP);
++			return 0;
++		} else {
++			usbip_event_add(ud, VDEV_EVENT_ERROR_TCP);
++			return -EPIPE;
++		}
++	}
++
+ 	ret = usbip_recv(ud->tcp_socket, urb->transfer_buffer, size);
+ 	if (ret != size) {
+ 		dev_err(&urb->dev->dev, "recv xbuf, %d\n", ret);
+-- 
+1.9.1
+

--- a/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
+++ b/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
@@ -5,7 +5,10 @@ LINUX_VERSION_corei7-64-intel-common = "4.4.3"
 SRCREV_machine_corei7-64-intel-common = "076cc85486fda808582bd1e77400a5c49dea3e2e"
 
 ### linux-stable/linux-4.4.y backports
-
+SRC_URI_append_intel-edison = " file://0001-USB-usbip-fix-potential-out-of-bounds-write.patch"
+SRC_URI_append_intel-quark = " file://0001-USB-usbip-fix-potential-out-of-bounds-write.patch"
+SRC_URI_append_intel-core2-32 = " file://0001-USB-usbip-fix-potential-out-of-bounds-write.patch"
+SRC_URI_append_intel-corei7-64 = " file://0001-USB-usbip-fix-potential-out-of-bounds-write.patch"
 
 ### Config "fix" fragments
 


### PR DESCRIPTION
Add patch to fix CVE-2016-3955 security vulnerability in USB stack.

Fixes: IOTOS-1537

Signed-off-by: Jussi Laako jussi.laako@linux.intel.com
