### PR TITLE
Enable support for TPM 2.0 CRB type devices

### DIFF
--- a/recipes-kernel/linux-yocto/linux-yocto/security-tpm.cfg
+++ b/recipes-kernel/linux-yocto/linux-yocto/security-tpm.cfg
@@ -1,0 +1,1 @@
+CONFIG_TCG_CRB=y

--- a/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
+++ b/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
@@ -22,6 +22,10 @@ SRC_URI_append_edison = " file://edison-iptables.cfg"
 
 ### Hardware support fragments
 
+# additional security hardware support
+SRC_URI_append_intel-core2-32 = " file://security-tpm.cfg"
+SRC_URI_append_intel-corei7-64 = " file://security-tpm.cfg"
+
 # generic support for Broxton platform
 SRC_URI_append_intel-corei7-64 = " file://broxton.cfg"
 


### PR DESCRIPTION
Add support for TPM 2.0 CRB type devices in order to support TPM
firmware implementations on Intel platforms.

Signed-off-by: Jussi Laako jussi.laako@linux.intel.com
