### PR TITLE
fix the incorrect device name for IIO device SI7020

### DIFF
--- a/recipes-kernel/linux-yocto/linux-yocto/0001-iio-si7020-Set-correct-iio-name.patch
+++ b/recipes-kernel/linux-yocto/linux-yocto/0001-iio-si7020-Set-correct-iio-name.patch
@@ -1,0 +1,33 @@
+From 28496a47d0338dc91fb34037332b2d43dce10715 Mon Sep 17 00:00:00 2001
+From: Yong Li <yong.b.li@intel.com>
+Date: Fri, 29 Apr 2016 14:46:57 +0800
+Subject: [PATCH] iio: si7020: Set correct iio name
+
+When load the driver using the below command:
+echo si7020 0x40 > /sys/bus/i2c/devices/i2c-0/new_device
+
+In sysfs, the i2c name is si7020, however the iio name is 0-0040,
+they are inconsistent. With this patch,
+the iio name will be the same as the i2c device name
+
+Signed-off-by: Yong Li <yong.b.li@intel.com>
+---
+ drivers/iio/humidity/si7020.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/iio/humidity/si7020.c b/drivers/iio/humidity/si7020.c
+index ffc2ccf..a3968db 100644
+--- a/drivers/iio/humidity/si7020.c
++++ b/drivers/iio/humidity/si7020.c
+@@ -138,7 +138,7 @@ static int si7020_probe(struct i2c_client *client,
+ 	*data = client;
+ 
+ 	indio_dev->dev.parent = &client->dev;
+-	indio_dev->name = dev_name(&client->dev);
++	indio_dev->name = id->name;
+ 	indio_dev->modes = INDIO_DIRECT_MODE;
+ 	indio_dev->info = &si7020_info;
+ 	indio_dev->channels = si7020_channels;
+-- 
+2.5.0
+

--- a/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
+++ b/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
@@ -45,6 +45,11 @@ SRC_URI_append_intel-corei7-64 = " file://0001-iio-tmp006-Set-correct-iio-name.p
 SRC_URI_append_intel-core2-32 = " file://0001-iio-tmp006-Set-correct-iio-name.patch"
 SRC_URI_append_intel-quark = " file://0001-iio-tmp006-Set-correct-iio-name.patch"
 
+# Add patch to fix incorrect device name of IIO device SI7020
+SRC_URI_append_intel-corei7-64 = " file://0001-iio-si7020-Set-correct-iio-name.patch"
+SRC_URI_append_intel-core2-32 = " file://0001-iio-si7020-Set-correct-iio-name.patch"
+SRC_URI_append_intel-quark = " file://0001-iio-si7020-Set-correct-iio-name.patch"
+
 #  BeagleBone Black enable all I2Cs
 SRC_URI_append_beaglebone = " file://0001-v3.15.0-ARM-dts-am335x-boneblack-configure-i2c1-and-2.patch"
 


### PR DESCRIPTION
When load the driver using the below command:
echo si7020 0x40 > /sys/bus/i2c/devices/i2c-0/new_device

In sysfs, the i2c name is si7020, however the iio name is 0-0040,
they are inconsistent. With this patch,
the iio name will be the same as the i2c device name

Fixes: IOTOS-1585
Upstream-Status:Pending

Signed-off-by: Yong Li yong.b.li@intel.com
