### PR TITLE
Add the APDS9960 proximity sensor kernel module for Minnowmax

### DIFF
--- a/recipes-extended/i2c-minnowmax-board/files/Makefile
+++ b/recipes-extended/i2c-minnowmax-board/files/Makefile
@@ -1,4 +1,4 @@
-obj-m := i2c-minnow-mpu6050.o
+obj-m := i2c-minnow-mpu6050.o i2c-minnow-apds9960.o
 SRC := $(shell pwd)
 
 all:

--- a/recipes-extended/i2c-minnowmax-board/files/i2c-minnow-apds9960.c
+++ b/recipes-extended/i2c-minnowmax-board/files/i2c-minnow-apds9960.c
@@ -1,0 +1,52 @@
+/*
+ * MinnowBoard-Max APDS9960 I2C sensor test file
+ * build command: KDIR=/kernel-source/ make
+ * The kernel config should include CONFIG_APDS9960=m
+ */
+
+#include <linux/module.h>
+#include <linux/gpio.h>
+#include <linux/i2c.h>
+
+#define APDS9960_I2C_ADDR		0x39
+
+/* The APDS9960 IRQ pin is connected to pin25(GPIO_S5_2) of LSE connector,
+ * On Linux >=3.18, it is GPIO 340
+ * For more information, visit the below
+ * http://www.elinux.org/Minnowboard:MinnowMax#Low_Speed_Expansion_.28Top.29
+ */
+#define APDS9960_I2C_IRQ		340
+
+static struct i2c_board_info apds9960_accel_device = {
+	I2C_BOARD_INFO("apds9960", APDS9960_I2C_ADDR),
+	.irq = -1,
+};
+
+static struct i2c_client *i2c_client;
+static int __init apds9960_init(void)
+{
+	int i = 0;
+	struct i2c_adapter *adap = NULL;
+
+	for (i = 0; i < 3; i++) {
+		adap = i2c_get_adapter(i);
+		if (!adap)
+			return -1;
+
+		if (!strcmp(adap->name, "Synopsys DesignWare I2C adapter"))
+			break;
+	}
+
+	apds9960_accel_device.irq = gpio_to_irq(APDS9960_I2C_IRQ);
+
+	i2c_client = i2c_new_device(adap, &apds9960_accel_device);
+	return 0;
+}
+
+static void __exit apds9960_exit(void)
+{
+	i2c_unregister_device(i2c_client);
+}
+MODULE_LICENSE("GPL");
+module_init(apds9960_init);
+module_exit(apds9960_exit);

--- a/recipes-extended/i2c-minnowmax-board/i2c-minnowmax-board.bb
+++ b/recipes-extended/i2c-minnowmax-board/i2c-minnowmax-board.bb
@@ -9,6 +9,7 @@ inherit module
 FILESEXTRAPATHS_prepend := "${THISDIR}/files/:"
 
 SRC_URI = "file://i2c-minnow-mpu6050.c \
+           file://i2c-minnow-apds9960.c \
            file://Makefile \
            "
 


### PR DESCRIPTION
The apds9960 device driver needs a GPIO as the IRQ resource,
Add this kernel module to provide the IRQ resource on Minnowmax boards

Signed-off-by: Yong Li yong.b.li@intel.com
