### PR TITLE
u-boot-edison: set cwd to ${B} for custom tasks

### DIFF
--- a/meta-edison-bsp/recipes-bsp/u-boot/u-boot-osip.inc
+++ b/meta-edison-bsp/recipes-bsp/u-boot/u-boot-osip.inc
@@ -5,15 +5,17 @@ OSIP_HANDOFF_POINTER = "17829888"
 # env is U-Boot primary environment where internal U-Boot variables are stored
 # this default generated binary environment, is embedded in a raw OSIP image
 # use by XFSTK tools to do the initial boot
-ENV_IMAGE = "${S}/env.bin"
-BASE_IMAGE = "${S}/u-boot.bin"
+ENV_IMAGE = "${B}/env.bin"
+BASE_IMAGE = "${B}/u-boot.bin"
 UBOOT_OSIP_SUFFIX = "img"
-UBOOT_TMP_IMG = "${S}/u-boot.${UBOOT_OSIP_SUFFIX}.no-osip"
-UBOOT_IMG = "${S}/u-boot.${UBOOT_OSIP_SUFFIX}"
+UBOOT_TMP_IMG = "${B}/u-boot.${UBOOT_OSIP_SUFFIX}.no-osip"
+UBOOT_IMG = "${B}/u-boot.${UBOOT_OSIP_SUFFIX}"
 UBOOT_OSIP_IMAGE = "u-boot-${MACHINE}-${PV}-${PR}.${UBOOT_OSIP_SUFFIX}"
 UBOOT_OSIP_BINARY = "u-boot.${UBOOT_OSIP_SUFFIX}"
 UBOOT_OSIP_SYMLINK = "u-boot-${MACHINE}.${UBOOT_OSIP_SUFFIX}"
 
+do_uboot_padding[dirs] = "${B}"
+do_uboot_uboot_env_mkimage[dirs] = "${B}"
 
 do_uboot_padding() {
     # U-Boot.bin map

--- a/meta-edison-bsp/recipes-bsp/u-boot/u-boot-target-env.inc
+++ b/meta-edison-bsp/recipes-bsp/u-boot/u-boot-target-env.inc
@@ -30,7 +30,10 @@ ENV_IFWI_TARGET_NAME="ifwi"
 # Env image is U-Boot primary environment (where internal U-Boot variables are stored)
 # The same vairiable is also defined in u-boot-osip recip in charge of doing stitching
 # process for IFWI
-ENV_IMAGE = "${S}/env.bin"
+ENV_IMAGE = "${B}/env.bin"
+
+do_build_mkimage_tool[dirs] = "${B}"
+do_environment_mkimage[dirs] = "${B}"
 
 do_build_mkimage_tool () {
    HOSTCC="${CC}" HOSTLD="${LD}" HOSTLDFLAGS="${LDFLAGS}" HOSTSTRIP=true oe_runmake  tools


### PR DESCRIPTION
After a change in bitbake (rev: 67a7b8b021badc17d8fdf447c250e79d291e75f7)
the cwd no longer defaults to ${B}. This makes many of the custom u-boot
tasks to fail since they expect the working directory is ${B}.

Fix the problems by using the documented mechanism by setting
do_some_task[dirs] = "${B}". In addition, make sure all other relevant
paths in environment variables now use ${B} too.

Signed-off-by: Mikko Ylinen mikko.ylinen@intel.com
