### PR TITLE
edison: "ldflags" package QA fixes

### DIFF
--- a/meta-edison-bsp/recipes-bsp/u-boot/u-boot-fw-utils-edison_2014.04.bb
+++ b/meta-edison-bsp/recipes-bsp/u-boot/u-boot-fw-utils-edison_2014.04.bb
@@ -10,6 +10,8 @@ SRC_URI += "file://fw_env.config"
 
 EXTRA_OEMAKE = 'CROSS_COMPILE=${TARGET_PREFIX} CC="${TARGET_PREFIX}gcc ${TOOLCHAIN_OPTIONS}"'
 
+INSANE_SKIP_${PN} += "ldflags"
+
 do_compile () {
   oe_runmake ${UBOOT_MACHINE}
   oe_runmake env

--- a/meta-edison-bsp/recipes-connectivity/bluetooth-rfkill-event/bluetooth-rfkill-event_1.0.bb
+++ b/meta-edison-bsp/recipes-connectivity/bluetooth-rfkill-event/bluetooth-rfkill-event_1.0.bb
@@ -23,14 +23,14 @@ INC_DIRS = "-I${STAGING_INCDIR}/glib-2.0 -I${STAGING_LIBDIR}/glib-2.0/include/"
 LIBS = "-lglib-2.0"
 
 do_compile() {
-        ${CC} $CFLAGS -o bluetooth_rfkill_event bluetooth_rfkill_event.c ${INC_DIRS} ${LIBS}
+        ${CC} $CFLAGS ${LDFLAGS} -o bluetooth_rfkill_event bluetooth_rfkill_event.c ${INC_DIRS} ${LIBS}
 }
 
 do_install() {
         install -v -d ${D}${sbindir}
         install -m 0755 bluetooth_rfkill_event ${D}${sbindir}
 
-        if ${@base_contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
                 # Copy file service
                 install -d ${D}/${systemd_unitdir}/system
                 install -m 644 ${WORKDIR}/bluetooth-rfkill-event.service ${D}/${systemd_unitdir}/system

--- a/meta-edison-bsp/recipes-kernel/bcm43340-bt/bcm43340-bt_1.0.bb
+++ b/meta-edison-bsp/recipes-kernel/bcm43340-bt/bcm43340-bt_1.0.bb
@@ -11,7 +11,7 @@ PR = "r1"
 S = "${WORKDIR}/git/broadcom_cws/bluetooth/firmware/"
 
 do_compile() {
-        ${CC} -O2 -Wall -o brcm_patchram_plus brcm_patchram_plus.c
+        ${CC} -O2 -Wall ${LDFLAGS} -o brcm_patchram_plus brcm_patchram_plus.c
 }
 
 do_install() {


### PR DESCRIPTION
Many edison recipes fail with "ldflags" package QA test. This PR skips/fixes the errors.
