### PR TITLE
intel-quark: use updated yocto-kernel-cache

### DIFF
--- a/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
+++ b/recipes-kernel/linux-yocto/linux-yocto_4.4.bbappend
@@ -135,3 +135,7 @@ SRC_URI_append_beaglebone = " \
 
 # lockdep and kernel debugging
 # SRC_URI_append = "  file://lockdep.cfg file://debug-kernel.cfg"
+
+# Temporarily use this yocto-kernel-cache commit to make intel-quark to compile
+# with the latest linux-yocto-4.% changes.
+SRCREV_meta_i586-nlp-32-intel-common = "698835841165b68089604398f68fd8bc3f79cb65"


### PR DESCRIPTION
Temporarily use the latest yocto-kernel-cache commit to make
intel-quark to compile with the latest linux-yocto-4.% changes.

This allows ostro-os to pull in updates from openembedded-core and
meta-intel.

Signed-off-by: Mikko Ylinen mikko.ylinen@intel.com
