### PR TITLE
meta-edison-bsp: u-boot: fix target_env archiving

### DIFF
--- a/meta-edison-bsp/recipes-bsp/u-boot/u-boot-internal.inc
+++ b/meta-edison-bsp/recipes-bsp/u-boot/u-boot-internal.inc
@@ -5,7 +5,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 SRC_URI = "git://github.com/01org/edison-u-boot.git;branch=edison-v2014.04;protocol=git" 
 SRC_URI += "${@'file://${MACHINE}.env' if '${MACHINE}' in ('edison',) else ''}"
-SRC_URI += "file://target_env/"
+SRC_URI += "file://target_env/;name=target-env"
 SRC_URI += "file://0001-Backport-compiler-gcc.h-from-4.2-kernel.patch"
 SRC_URI += "file://0002-Fix-weak-external-function-references-for-gcc5.patch"
 SRC_URI += "file://0001-Fix-missing-stdint.h-include.patch"


### PR DESCRIPTION
With the recent archiver.bbclass changes in oe-core an error
in do_ar_original was triggered when archiving u-boot.

It turns out archiver detects 'file://target_env/' as another
source URL and wants a unique repo name for it (or the original
source).

To avoid the need to change the archiver.bbclass logic, just give
a unique name to target_env "repo" (directory).

While debugging this, it was noticed the old archiver.bbclass was
not archiving file://target_env/ at all. This change (together with
the new archiver.bbclass) fixes that too.

Signed-off-by: Mikko Ylinen mikko.ylinen@intel.com
